### PR TITLE
change regex to delete all the unnecessary qemu binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -132,7 +132,7 @@ RUN set -x && \
     fi && \
     apt-get autoremove -y && \
     # delete unnecessary qemu binaries to save lots of space
-    { find /usr/bin -regex '/usr/bin/qemu-.*-static'  | grep -v qemu-arm-static | xargs rm -vf {} || true; } && \
+    { find /usr/bin -regex '/usr/bin/qemu-.*'  | grep -v qemu-arm-static | xargs rm -vf {} || true; } && \
     rm -rf /src/* /tmp/* /var/lib/apt/lists/*
 
 # add AIS-catcher and libairspyhf


### PR DESCRIPTION
apparently the package qemu-arm-static has non-static binaries included somehow now?