### PR TITLE
ci: fix persistent hadolint failure in Deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,16 +43,6 @@ jobs:
         run: |
           echo "Workflow dispatch reason: $INPUTS_REASON"
 
-  hadolint:
-    name: Run hadolint against docker files
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Pull hadolint/hadolint:latest Image
-        run: docker pull hadolint/hadolint:latest
-      - name: Run hadolint against Dockerfiles
-        run: docker run --rm -i -v "$PWD":/workdir --workdir /workdir --entrypoint hadolint hadolint/hadolint --ignore DL3015 --ignore DL3003 --ignore DL3006 --ignore DL3010 --ignore DL4001 --ignore DL3007 --ignore DL3008 --ignore SC2068 --ignore DL3007 --ignore SC1091 --ignore DL3013 --ignore DL3010 $(find . -type f -iname "Dockerfile*")
-
   build_and_push:
     name: Image Build & Push
     uses: sdr-enthusiasts/common-github-workflows/.github/workflows/sdre.yml@bcf0b94a192e7ca9630f788ecc16acd999541404 # main

--- a/Dockerfile
+++ b/Dockerfile
@@ -159,4 +159,4 @@ RUN set -x && \
 COPY rootfs/ /
 
 # Add healthcheck
-HEALTHCHECK --start-period=60s --interval=120s --timeout=100s CMD /healthcheck/healthcheck.sh
+HEALTHCHECK --start-period=60s --interval=120s --timeout=100s CMD ["/healthcheck/healthcheck.sh"]

--- a/Dockerfile.build-aiscatcher
+++ b/Dockerfile.build-aiscatcher
@@ -102,4 +102,4 @@ RUN set -x && \
     rm -rf /tmp/*
 
 # Add healthcheck
-HEALTHCHECK --start-period=60s --interval=600s --timeout=60s CMD /healthcheck/healthcheck.sh
+HEALTHCHECK --start-period=60s --interval=600s --timeout=60s CMD ["/healthcheck/healthcheck.sh"]

--- a/renovate.json
+++ b/renovate.json
@@ -5,25 +5,17 @@
     "config:best-practices",
     "default:pinDigestsDisabled"
   ],
-  "lockFileMaintenance": {
-    "enabled": true,
-    "automerge": true,
-    "schedule": ["* 0 1 * *"]
-  },
   "timezone": "Etc/UTC",
   "schedule": ["* 0 1 * *"],
-  "enabledManagers": ["nix", "github-actions", "dockerfile"],
+  "enabledManagers": ["github-actions", "dockerfile"],
   "prConcurrentLimit": 0,
   "prHourlyLimit": 0,
   "prCreation": "immediate",
   "automerge": true,
   "platformAutomerge": true,
-  "nix": {
-    "enabled": true
-  },
   "packageRules": [
     {
-      "matchManagers": ["github-actions", "nix"],
+      "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["major", "minor", "patch", "pin"],
       "automerge": true
     },


### PR DESCRIPTION
## Problem

Every `Deploy` run since 2026-07-30 has shown a red X, even though the image built and pushed successfully. The only failing job was `Run hadolint against docker files`:

```text
failure  Run hadolint against docker files
success  Image Build & Push / Prepare workflow environment
success  Image Build & Push / Build (manifest) (ubuntu-24.04-arm, arm64, linux/arm64, true)
success  Image Build & Push / Build (manifest) (ubuntu-24.04-arm, arm32, linux/arm/v7, true)
success  Image Build & Push / Build (manifest) (ubuntu-latest, linux/amd64, true)
success  Image Build & Push / merge
```

## Root cause

The job pulled unpinned `hadolint/hadolint:latest`, so it silently adopted upstream rule changes. hadolint [#1209](https://github.com/hadolint/hadolint/pull/1209) extended `DL3025` to trigger on `HEALTHCHECK` instructions as well as `CMD`/`ENTRYPOINT`, and shipped in **v2.15.0, published 2026-07-30T13:39:01Z**. The `Deploy` history brackets that release exactly:

| Run | Time (UTC) | hadolint job |
|-------------|------------------------|---------|
| 30522233560 | 2026-07-30T07:13:52Z | success |
| *v2.15.0 released* | *2026-07-30T13:39:01Z* | |
| 30574739966 | 2026-07-30T19:25:08Z | failure |

Nothing in the Dockerfiles changed. Reproduced against both versions:

```console
$ printf 'FROM debian:bookworm-slim\nHEALTHCHECK CMD /hc.sh\n' > Dockerfile.hc

$ hadolint Dockerfile.hc                    # 2.14.0, the flake.lock pin
rc=0

$ docker run --rm -i --entrypoint hadolint hadolint/hadolint:latest - < Dockerfile.hc
-:2 DL3025 warning: Use arguments JSON notation for CMD and ENTRYPOINT arguments
rc=1
```

## Changes

**`fix: use JSON exec form for HEALTHCHECK CMD`** — the actual violation, in both Dockerfiles:

```diff
-HEALTHCHECK --start-period=60s --interval=120s --timeout=100s CMD /healthcheck/healthcheck.sh
+HEALTHCHECK --start-period=60s --interval=120s --timeout=100s CMD ["/healthcheck/healthcheck.sh"]
```

This matters beyond the deleted job: the shared pre-commit ruleset sets `failure-threshold: warning`, so the `Lint` job on every PR would start failing the moment `flake.lock` picks up a nixpkgs carrying hadolint 2.15.x. Fixing it now closes that off.

**`ci: drop redundant hadolint job from deploy workflow`** — linting does not belong in the deploy path, and `lint.yaml` already runs hadolint over both Dockerfiles on every PR via pre-commit, against a version pinned through `flake.lock` rather than a floating tag. Coverage is unchanged.

**`chore(renovate): drop nix manager and lockFileMaintenance`** — the `nix` manager duplicated `update-flakes.yaml`, which already opens per-input `flake.lock` PRs weekly via `fredsystems/flake-update-action`; both enabled meant two mechanisms competing over the same file. With `nix` gone neither remaining manager has a lockfile, so `lockFileMaintenance` was inert.

## Verification

The exec form removes the intervening `/bin/sh -c`, so the kernel must resolve the script's unusual `#!/command/with-contenv bash` shebang itself. Confirmed the preconditions hold in the published image:

```console
$ docker run --rm --entrypoint /bin/sh ghcr.io/sdr-enthusiasts/docker-shipfeeder:latest \
    -c 'ls -l /command/with-contenv; ls -l /healthcheck/healthcheck.sh'
lrwxrwxrwx 1 root root 48 Jan 24  2026 /command/with-contenv -> ../package/admin/s6-overlay/command/with-contenv
-rwxr-xr-x 1 root root 1651 Aug  4 10:37 /healthcheck/healthcheck.sh
```

Then ran both forms side by side on `docker-baseimage:base` with the identical shebang, driven by Docker's real healthcheck machinery:

```text
=== shell ===                                === exec ===
healthy                                      healthy
["CMD-SHELL","/healthcheck/healthcheck.sh"]  ["CMD","/healthcheck/healthcheck.sh"]
exit=0 out="ran ok\n"                        exit=0 out="ran ok\n"
```

And the failure direction, confirming exit codes still propagate:

```text
status: unhealthy
exit=1 out="failing\n"
```

The command is a bare absolute path with no arguments, so no shell functionality is lost. Arguably more correct too — `sh -c` never supplied the s6 container environment anyway, which is what `with-contenv` is for.

Also checked:

- hadolint **2.14.0** (current pin) and **2.15.1** (`:latest`): both `rc=0` on the patched Dockerfiles
- `docker build --platform linux/amd64 -f Dockerfile`: succeeds; resulting config is `{"Test":["CMD","/healthcheck/healthcheck.sh"],"Interval":120000000000,"Timeout":100000000000,"StartPeriod":60000000000}` — intervals unchanged from the published image
- `renovate-config-validator --strict`: `Config validated successfully`
- `pre-commit run --all-files` green at **each of the three commits** individually, not just at the tip
